### PR TITLE
승리 + 3-3 or 4-4인 경우 로직 수정

### DIFF
--- a/src/main/kotlin/rule/BlackRenjuRule.kt
+++ b/src/main/kotlin/rule/BlackRenjuRule.kt
@@ -35,11 +35,6 @@ class BlackRenjuRule(
         startPoint: Point,
         foul: Foul,
     ): KoRule {
-        // Even if it is 3-3 or 4-4, it is not a KO if 5 are in a row.
-        if (checkSerialSameStonesBiDirection(blackPoints, startPoint, WIN_STANDARD)) {
-            return KoRule.NOT_KO
-        }
-
         var continuousStones = 0
         val dirIterator = Directions().iterator()
 

--- a/src/main/kotlin/rule/OmokRule.kt
+++ b/src/main/kotlin/rule/OmokRule.kt
@@ -30,9 +30,7 @@ abstract class OmokRule(
         val satisfyWin = checkSerialSameStonesBiDirection(blackPoints, startPoint, WIN_STANDARD)
         val koState = checkAllFoulCondition(blackPoints, whitePoints, startPoint)
 
-        if (satisfyWin && koState == KoRule.NOT_KO) {
-            return true
-        }
+        if (satisfyWin && koState != KoRule.KO_OVERLINE) return true
         return false
     }
 
@@ -49,12 +47,13 @@ abstract class OmokRule(
         blackPoints: List<Point>,
         whitePoints: List<Point>,
         startPoint: Point,
-    ): KoRule = if (listOf(
+    ): KoRule {
+        return listOf(
             checkDoubleFoul(blackPoints, whitePoints, startPoint, Foul.DOUBLE_THREE),
             checkDoubleFoul(blackPoints, whitePoints, startPoint, Foul.DOUBLE_FOUR),
-            checkOverline(blackPoints, startPoint)
-        ).any { it.state }
-    ) KoRule.KO_ALL else KoRule.NOT_KO
+            checkOverline(blackPoints, startPoint),
+        ).last { it.state }
+    }
 
     /**
      * check 'three-three' point or 'four-four' point according to the given 'foul type'

--- a/src/main/kotlin/rule/wrapper/direction/DirectionsIterator.kt
+++ b/src/main/kotlin/rule/wrapper/direction/DirectionsIterator.kt
@@ -11,9 +11,7 @@ internal class DirectionsIterator(items: List<Direction<Row, Col>>) : Iterator<D
     override fun hasNext(): Boolean = _items.isNotEmpty()
 
     override fun next(): Direction<Row, Col> {
-        if (hasNext()) {
-            return _items.removeFirst()
-        }
+        if (hasNext()) return _items.removeFirst()
         throw IllegalStateException("The next direction does not exist.")
     }
 

--- a/src/test/kotlin/rule/BlackRenjuRuleTest.kt
+++ b/src/test/kotlin/rule/BlackRenjuRuleTest.kt
@@ -69,8 +69,11 @@ class BlackRenjuRuleTest {
     fun `Black stone is a foul in the case of overline`() {
         // given
         val blackStones = listOf(
-            Point(5, 5), Point(6, 6), Point(7, 7),
-            Point(9, 9), Point(10, 10),
+            Point(5, 5),
+            Point(6, 6),
+            Point(7, 7),
+            Point(9, 9),
+            Point(10, 10),
         )
         val newStone = Point(8, 8)
 
@@ -82,14 +85,36 @@ class BlackRenjuRuleTest {
     }
 
     @Test
-    fun `If 5 black stones are in a row, it is not a foul even if it is double three  or double four`() {
+    fun `If 5 black stones are in a row, it is not a foul even if it is double four`() {
         // given
         val blackStones = listOf(
-            Point(5, 5), Point(5, 6), Point(6, 7),
-            Point(7, 7), Point(5, 8), Point(5, 9),
+            Point(5, 5), Point(5, 6),
+            Point(5, 8), Point(5, 9),
+            Point(6, 6), Point(6, 8),
+            Point(4, 6), Point(4, 8),
+            Point(3, 5), Point(3, 9),
         )
         val whiteStones = listOf<Point>()
         val newStone = Point(5, 7)
+
+        // when
+        val expected = renjuRule.checkAllFoulCondition(blackStones, whiteStones, newStone)
+
+        // then
+        assertThat(expected).isEqualTo(KoRule.NOT_KO)
+    }
+
+    @Test
+    fun `If 5 black stones are in a row, it is not a foul even if it is double three`() {
+        // given
+        val blackStones = listOf(
+            Point(5, 5), Point(5, 7),
+            Point(5, 8), Point(5, 9),
+            Point(4, 5), Point(4, 6),
+            Point(6, 6), Point(6, 7),
+        )
+        val whiteStones = listOf<Point>()
+        val newStone = Point(5, 6)
 
         // when
         val expected = renjuRule.checkAllFoulCondition(blackStones, whiteStones, newStone)

--- a/src/test/kotlin/rule/BlackRenjuRuleTest.kt
+++ b/src/test/kotlin/rule/BlackRenjuRuleTest.kt
@@ -85,7 +85,7 @@ class BlackRenjuRuleTest {
     }
 
     @Test
-    fun `If 5 black stones are in a row, it is not a foul even if it is double four`() {
+    fun `If 5 black stones are in a row, it is win even if it is double four`() {
         // given
         val blackStones = listOf(
             Point(5, 5), Point(5, 6),
@@ -105,7 +105,7 @@ class BlackRenjuRuleTest {
     }
 
     @Test
-    fun `If 5 black stones are in a row, it is not a foul even if it is double three`() {
+    fun `If 5 black stones are in a row, it is win even if it is double three`() {
         // given
         val blackStones = listOf(
             Point(5, 5), Point(5, 7),

--- a/src/test/kotlin/rule/BlackRenjuRuleTest.kt
+++ b/src/test/kotlin/rule/BlackRenjuRuleTest.kt
@@ -98,10 +98,10 @@ class BlackRenjuRuleTest {
         val newStone = Point(5, 7)
 
         // when
-        val expected = renjuRule.checkAllFoulCondition(blackStones, whiteStones, newStone)
+        val expected = renjuRule.checkWin(blackStones, whiteStones, newStone)
 
         // then
-        assertThat(expected).isEqualTo(KoRule.NOT_KO)
+        assertThat(expected).isTrue
     }
 
     @Test
@@ -117,9 +117,9 @@ class BlackRenjuRuleTest {
         val newStone = Point(5, 6)
 
         // when
-        val expected = renjuRule.checkAllFoulCondition(blackStones, whiteStones, newStone)
+        val expected = renjuRule.checkWin(blackStones, whiteStones, newStone)
 
         // then
-        assertThat(expected).isEqualTo(KoRule.NOT_KO)
+        assertThat(expected).isTrue
     }
 }


### PR DESCRIPTION
1. Kotlin Convention 일부 수정
2. 승리지만 3-3 or 4-4인 경우 승리 판단을 checkWin에서 하도록 수정 (함수를 중복하여 호출하지 않도록)